### PR TITLE
Fix issue with & operand in \state\store.py save

### DIFF
--- a/pycord/state/store.py
+++ b/pycord/state/store.py
@@ -68,7 +68,7 @@ class Store:
             if len(self._store) == self.max_items:
                 self._store = {}
 
-            store = _stored(parents, id, data)
+            store = _stored(set(parents), id, data)
             self._store.add(store)
 
     async def discard(self, parents: list[Any], id: Any) -> Any | None:


### PR DESCRIPTION
## Summary

Fix where the list was thrown into the store so the & operator did not work.

Example traceback:
```
E 2022-12-25 13:18:35,350 asyncio: Task exception was never retrieved
future: <Task finished name='Task-2121' coro=<State._process_event() done, defined at \pycord\state\core.py:121> exception=TypeError("unsupported operand type(s) for &: 'list' and 'set'")>
Traceback (most recent call last):
  File "\pycord\state\core.py", line 230, in _process_event
    res = await (self.store.sift('members')).save(
  File "\pycord\state\store.py", line 61, in save
    if store.parents & ps and store.id == id:
TypeError: unsupported operand type(s) for &: 'list' and 'set'
```


## Checklist

- [ ] This PR has breaking changes
- [x] This PR fixes an issue
- [ ] This is **not** a code change
- [x] If code changes were made they have been tested
- [ ] I have properly changed the docs to appeal to this change
