### PR TITLE
fix: 'Queue.put' was never awaited

### DIFF
--- a/pycord/api/execution/executer.py
+++ b/pycord/api/execution/executer.py
@@ -61,5 +61,5 @@ class Executer:
 
         event = asyncio.Event()
 
-        self._request_queue.put(event)
+        await self._request_queue.put(event)
         await event.wait()

--- a/pycord/state/store.py
+++ b/pycord/state/store.py
@@ -68,7 +68,7 @@ class Store:
             if len(self._store) == self.max_items:
                 self._store = {}
 
-            store = _stored(parents, id, data)
+            store = _stored(set(parents), id, data)
             self._store.add(store)
 
     async def discard(self, parents: list[Any], id: Any) -> Any | None:


### PR DESCRIPTION
## Summary

Fix issue with put to Queue in executer:
```shell
W 2023-01-11 01:53:06,899 py.warnings: \pycord\api\execution\executer.py:64: RuntimeWarning: coroutine 'Queue.put' was never awaited
  self._request_queue.put(event)

E 2023-01-11 01:53:20,893 asyncio: Task was destroyed but it is pending!
task: <Task pending name='Task-111' coro=<ApplicationCommand._invoke() done, defined at \pycord\commands\application\command.py:694> wait_for=<Future pending cb=[Task.task_wakeup()]>>
```

## PR Type

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR improves the code (speed/style improvements or refactoring).
- [x] This PR fixes an issue.
- [ ] This PR makes an addition to the library (new file, class, method, parameters, etc.).
- [ ] This PR makes a breaking change (renaming/removing parameters, methods, etc.).
- [ ] This PR doesn't make any code changes to the library (documentation, examples).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched all pull requests for duplicates.
- [x] I have tested the changes made.
  - [ ] I have properly changed the docs to reflect the changes made.
- [ ] If 'type: ignore' comments were used, a comment is left to explain why it is needed.
